### PR TITLE
Dependabot Grouped Version - Notice

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ GitHub uses this Action to combine multiple dependabot PRs into a single one. Ra
 
 This Action is customizable so you can use it for your own purposes and it doesn't have to be specific to dependabot PRs.
 
+## Notice 📢
+
+> [!NOTE]
+> A notice around the [Dependabot Grouped Version Updates feature](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)
+
+As mentioned above is this README, a core reason why this Action exists is to "combine multiple Dependabot PRs into one". Work for this Action was completed before the [GitHub Blog Post](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/) was published and the Dependabot Grouped Version Updates feature was released. While it may seem like this Action is no longer needed due to this feature, there are actually still quite a few use cases for this Action. The first one that is front of mind is that the PRs which Dependabot opens are grouped by package manager. This means that if you have a project that uses multiple package managers, you'll still end up with multiple PRs. This Action can be used to combine those PRs into a single one. You may also want to combine pull requests that are not related to Dependabot in anyway, which this Action can also do.
+
 ## Inputs 📝
 
 | Name | Description | Default | Required |


### PR DESCRIPTION
# Dependabot Grouped Version - Notice

This pull request adds a notice to the readme about the recent [Dependabot Grouped Version Feature](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/) that was released.

---

resolves: https://github.com/github/combine-prs/issues/24