### PR TITLE
fix(check-status): add null check for commit status rollup

### DIFF
--- a/src/functions/check-status.js
+++ b/src/functions/check-status.js
@@ -45,7 +45,7 @@ export async function checkStatus(
           statusOK = false
         }
       } else {
-        core.info('No status check associated with the commit')
+        core.info('No status check associated with branch: ' + branch)
         statusOK = false
       }
     }

--- a/src/functions/check-status.js
+++ b/src/functions/check-status.js
@@ -37,10 +37,15 @@ export async function checkStatus(
     // Check for CI status
     if (mustBeGreen) {
       const [{commit}] = result.repository.pullRequest.commits.nodes
-      const state = commit.statusCheckRollup.state
-      core.info('Validating status: ' + state)
-      if (state !== 'SUCCESS') {
-        core.info('Discarding ' + branch + ' with status ' + state)
+      if (commit.statusCheckRollup) {
+        const state = commit.statusCheckRollup.state
+        core.info('Validating status: ' + state)
+        if (state !== 'SUCCESS') {
+          core.info('Discarding ' + branch + ' with status ' + state)
+          statusOK = false
+        }
+      } else {
+        core.info('No status check associated with the commit')
         statusOK = false
       }
     }


### PR DESCRIPTION
This is related to #39.

This commit addresses a TypeError that occurs when trying to access the 'state' property of 'commit.statusCheckRollup' when it is null. A conditional check is added to ensure 'commit.statusCheckRollup' is not null before attempting to access 'state'. This prevents the TypeError and provides a more informative message when 'commit.statusCheckRollup' is null.

However, this would not solve the underlying issue of why commit.statusCheckRollup is null when it shouldn't be (see #39).

Also, if commit.statusCheckRollup being null is a valid state that indicates a certain condition (e.g., the CI status check has not been run yet), then the logic within checkStatus() may need to be updated to handle this condition appropriately.