### PR TITLE
Pin and upgrade all immutable-eligible actions to their semantic versions

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -39,7 +39,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+      - uses: actions/upload-artifact@4.4.3
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist


### PR DESCRIPTION
Hello from Product Security! 👋

We noticed that at least one of your Actions workflows is using one or more eligible immutable actions without semantic versioning. This PR will update the workflow to use the latest version of the action, using semantic versioning to opt into immutable actions.

### Why is this important?

Using an immutable action without indicating proper semantic version will result in the version being resolved to a tag that is mutable. This means the action code can between runs and without your knowledge.

Using an immutable action with proper semantic versioning will resolve to the **exact** version of the action stored in the GitHub package registry. The action code will not change between runs. This is a key security control to ensure the code you are running is the code you expect.

Thanks and happy coding! 🎉
